### PR TITLE
Embed scripts inside Grotsky interpreter and create redistributable CLI tools

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,10 +21,54 @@ dependencies = [
 ]
 
 [[package]]
+name = "cfg-if"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "const-random"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87e00182fe74b066627d63b85fd550ac2998d4b0bd86bfed477a0ae4c7c71359"
+dependencies = [
+ "const-random-macro",
+]
+
+[[package]]
+name = "const-random-macro"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9d839f2a20b0aee515dc581a6172f2321f96cab76c1a38a4c584a194955390e"
+dependencies = [
+ "getrandom",
+ "once_cell",
+ "tiny-keccak",
+]
+
+[[package]]
+name = "crunchy"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
+
+[[package]]
+name = "getrandom"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94b22e06ecb0110981051723910cbf0b5f5e09a2062dd7663334ee79a9d1286c"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
+]
+
+[[package]]
 name = "grotsky-rs"
 version = "0.0.8"
 dependencies = [
  "bincode",
+ "const-random",
  "regex",
  "serde",
  "socket2",
@@ -41,6 +85,12 @@ name = "memchr"
 version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "523dc4f511e55ab87b694dc30d0f820d60906ef06413f93d4d7a1385599cc149"
+
+[[package]]
+name = "once_cell"
+version = "1.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
 name = "proc-macro2"
@@ -131,10 +181,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "tiny-keccak"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
+dependencies = [
+ "crunchy",
+]
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
+
+[[package]]
+name = "wasi"
+version = "0.11.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "windows-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,13 +3,12 @@ name = "grotsky-rs"
 version = "0.0.8"
 edition = "2021"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
 bincode = "1.3.3"
 serde = { version = "1.0.190", features = ["derive"] }
 socket2 = "0.5.5"
 regex = "1.10.2"
+const-random = "0.1.18"
 
 
 [profile.release]

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ benchmark_fib: grotsky grotsky-rs
 	python tool/benchmark.py $(BUILD_DIR)/grotsky $(BUILD_DIR)/grotsky-rs fib
 
 benchmark_objects: grotsky grotsky-rs
-	python tool/benchmark.py $(BUILD_DIR)/grotsky $(BUILD_DIR)/grotsky-rs fib
+	python tool/benchmark.py $(BUILD_DIR)/grotsky $(BUILD_DIR)/grotsky-rs objects
 
 test_grotsky: grotsky
 	@ cd archive && go test -v ./... -interpreter Go

--- a/readme.md
+++ b/readme.md
@@ -7,13 +7,94 @@ Grotsky is a toy programming language. Implemented in Rust as a Bytecode registe
 
 Grotsky is inspired a little bit by go, python and javascript. Uses a C-like style syntax with curly braces but no semicolons, includes some basic collections like lists and dicts. Also has the hability to listen to tcp ports, read environment variables and import modules.
 
-## Overview
+It has the ability to compile to bytecode and also to embed scripts into a distributable binary.
+
+# Table of Contents
+1. [Usage](#usage)
+    - [Run Scripts](#run-scripts)
+    - [Compile Scripts](#compile-scripts)
+    - [Embed Scripts](#embed-scripts)
+2. [Literals](#literals)
+3. [Print: Hello World](#print-hello-world)
+4. [Comments](#comments)
+5. [Arithmetic Expressions](#arithmetic-expressions)
+6. [Comparison and Logical Expressions](#comparison-and-logical-expressions)
+7. [Lists](#lists)
+8. [Dicts](#dicts)
+9. [Conditionals](#conditionals)
+10. [Loops](#loops)
+    - [While Loop](#while-loop)
+    - [Classic For Loop](#classic-for-loop)
+    - [Enhanced For Loop](#enhanced-for-loop)
+        - [Iterate List](#iterate-list)
+        - [Iterate Dict](#iterate-dict)
+        - [Unpacked List of Lists](#unpacked-list-of-lists)
+11. [Functions and Closures](#functions-and-closures)
+12. [Classes](#classes)
+    - [Simple Class](#simple-class)
+    - [Superclasses](#superclasses)
+    - [Magic Methods](#magic-methods)
+13. [Modules](#modules)
+14. [Net Utils](#net-utils)
+    - [TCP Socket](#tcp-socket)
+15. [ENV Variables](#env-variables)
+16. [Try-Catch](#try-catch)
+
+## Usage
 
 Get executable from [releases](https://github.com/mliezun/grotsky/releases/).
 
-Run using `$ ./grotsky source.gr`
+Run from command line:
 
-### Literals
+```
+$ ./grotsky
+Usage:
+    grotsky [script.gr | bytecode.grc]
+    grotsky compile script.gr
+    grotsky embed bytecode.grc
+```
+
+### Run Scripts
+
+Create a Grotsky script, which consists of a text file with the `.gr` extension.
+
+Then it can be executed by running the following command:
+
+```
+$ ./grotsky script.gr
+```
+
+### Compile Scripts
+
+The Grotsky interpreter provides the ability to compile scripts to bytecode.
+
+```
+$ ./grotsky compile script.gr
+```
+
+Generates a new file called `script.grc` located alongside the input file.
+
+The compiled file can then be executed by running:
+
+```
+$ ./grotsky script.grc
+```
+
+### Embed Scripts
+
+First, the input script needs to be [compiled](#compile-scripts).
+
+Then it can be embbeded into an executable binary that only runs that script.
+
+```
+$ ./grotsky embed script.grc
+```
+
+The resulting binary with the embedded code will be located alongside the input file and named with the `.exe` extension, for the previous example the file would be `script.exe`.
+
+> NOTE: Currently Grotsky only supports embedding a single file, which means importing modules might not work as expected.
+
+## Literals
 
 - `strings`: "String A"
 - `numbers`: 10, 10.04, 3.14, -1
@@ -21,19 +102,19 @@ Run using `$ ./grotsky source.gr`
 - `lists`: ["a", 1, 2]
 - `dicts`: {"a": 1}
 
-### Hello World
+## Print: Hello World
 
 ```js
 io.println("Hello world!")
 ```
 
-### Comments
+## Comments
 
 ```js
 # Comments start with '#'
 ```
 
-### Arithmetic Expressions
+## Arithmetic Expressions
 
 ```js
 io.println(
@@ -47,7 +128,7 @@ Outputs
 27 16
 ```
 
-### Comparison & Logical Expressions
+## Comparison and Logical Expressions
 
 ```js
 io.println(
@@ -61,7 +142,7 @@ Outputs:
 true false
 ```
 
-### Lists
+## Lists
 
 ```js
 let list = [
@@ -80,7 +161,7 @@ Outputs:
 ["a", "b", "c", "d", "e"]
 ```
 
-### Dicts
+## Dicts
 
 ```js
 let dict = {
@@ -97,7 +178,7 @@ Outputs:
 {"c": 3, "a": 1, "b": 2}
 ```
 
-### Conditionals
+## Conditionals
 
 ```js
 let a = 10
@@ -115,9 +196,9 @@ Outputs:
 a is less than or equal to ten and bigger than five
 ```
 
-### Loops
+## Loops
 
-#### While-Loop
+### While Loop
 
 ```
 let str = ""
@@ -135,7 +216,7 @@ Outputs:
 aaaaaaaaaa
 ```
 
-#### Classic For-Loop
+### Classic For Loop
 
 ```js
 let list = []
@@ -150,9 +231,9 @@ Outputs:
 [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
 ```
 
-#### Enhanced For-Loop
+### Enhanced For-Loop
 
-##### Iterate List
+#### Iterate List
 ```js
 let list = [0, 1, 2, 3, 4]
 for i in list {
@@ -169,7 +250,7 @@ Outputs:
 4
 ```
 
-##### Iterate Dict
+#### Iterate Dict
 ```js
 let dict = {
     "a": 1,
@@ -188,7 +269,7 @@ c 3
 a 1
 ```
 
-##### Unpacked List of Lists
+#### Unpacked List of Lists
 
 ```js
 let listOfLists = [
@@ -208,7 +289,7 @@ b 2 4
 c 3 5
 ```
 
-### Functions and Closures
+## Functions and Closures
 
 ```js
 fn makeCounter() {
@@ -234,9 +315,9 @@ Outputs:
 3
 ```
 
-### Classes
+## Classes
 
-#### Simple Class
+### Simple Class
 
 ```js
 class A {
@@ -258,7 +339,7 @@ Outputs:
 N: 10
 ```
 
-#### Superclasses
+### Superclasses
 
 ```js
 class A {
@@ -296,7 +377,7 @@ Printing:
 Printing: Hell
 ```
 
-#### Magic Methods
+### Magic Methods
 
 Available magic methods: add, sub, div, mod, mul, pow, neg, eq, neq, lt, lte, gt, gte.
 
@@ -326,7 +407,7 @@ Outputs:
 Magic is: 3
 ```
 
-### Modules
+## Modules
 
 File `utils.gr`:
 ```js
@@ -351,9 +432,9 @@ Outputs:
 [1, 2, 4, 8, 16]
 ```
 
-### Net utils
+## Net utils
 
-#### TCP Socket
+### TCP Socket
 
 ```js
 let socket = net.listenTcp("127.0.0.1", "6500")
@@ -380,7 +461,7 @@ Outputs:
 Received connection from: 127.0.0.1:52238
 ```
 
-### Env Variables
+## Env Variables
 
 ```js
 let lang = env.Get("LANG")
@@ -392,7 +473,7 @@ Outputs:
 en_US.UTF-8
 ```
 
-### Try-Catch
+## Try-Catch
 
 ```js
 try {

--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -179,7 +179,8 @@ impl Compiler {
             || var_name == "env".to_string()
             || var_name == "import".to_string()
             || var_name == "net".to_string()
-            || var_name == "re".to_string();
+            || var_name == "re".to_string()
+            || var_name == "process".to_string();
     }
 
     pub fn is_global_var(&self, var_name: String) -> bool {

--- a/src/embed.rs
+++ b/src/embed.rs
@@ -1,0 +1,80 @@
+use std::env;
+use std::{fs::{read, write}, process::exit, ptr};
+
+use const_random::const_random;
+
+use crate::interpreter;
+
+#[repr(C)]
+struct Marker {
+    magic_pattern: [u8; 512],
+    is_embedded: u8,
+}
+
+const fn new_marker() -> Marker {
+    Marker{
+        magic_pattern: const_random!([u8; 512]),
+        is_embedded: 0,
+    }
+}
+
+static EMBEDDED_MARKER: Marker = new_marker();
+
+pub fn is_embedded() -> bool {
+    let embedded_indicator = &EMBEDDED_MARKER.is_embedded as *const u8;
+    unsafe {
+        // Need to perform this trick to read the actual memory location.
+        // Otherwise during compilation Rust does static analysis and assumes
+        // this function always returns the same value.
+        return ptr::read_volatile(embedded_indicator) != 0;
+    }
+}
+
+fn magic_pattern() -> &'static[u8; 512] {
+    &EMBEDDED_MARKER.magic_pattern
+}
+
+fn find_position(haystack: &Vec<u8>, needle: &[u8; 512]) -> Option<usize> {
+    if haystack.len() < needle.len() {
+        return None;
+    }
+    for i in 0..=haystack.len() - needle.len() {
+        if &haystack[i..i + needle.len()] == needle.as_ref() {
+            return Some(i);
+        }
+    }
+    None
+}
+
+pub fn embed_file(compiled_script: String, output_binary: String) {
+    let exe_path = env::current_exe().unwrap();
+    let mut exe_contents = read(exe_path).unwrap();
+    let pattern = magic_pattern();
+    if let Some(pos) = find_position(&exe_contents, pattern) {
+        exe_contents[pos+512] = 1;
+        let mut compiled_content = read(compiled_script).unwrap();
+        for i in 0..512 {
+            exe_contents.push(pattern[i]);
+        }
+        exe_contents.append(&mut compiled_content);
+        write(output_binary, exe_contents).unwrap();
+    }
+}
+
+pub fn execute_embedded() {
+    let exe_path = env::current_exe().unwrap();
+    interpreter::set_absolute_path(exe_path.clone().to_str().unwrap().to_string());
+
+    let exe_contents = read(exe_path).unwrap();
+    let pattern = magic_pattern();
+    let offset: usize = 512;
+    let first_match = find_position(&exe_contents, pattern).unwrap();
+    let remaining = &exe_contents[first_match+offset..].to_vec();
+    let pos = find_position(remaining, pattern).unwrap();
+    let compiled_content = &remaining[pos+offset..];
+    
+    if !interpreter::run_interpreter_from_bytecode(&compiled_content) {
+        println!("Could not read embedded script");
+        exit(1);
+    }
+}

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -85,6 +85,10 @@ fn setup_global_interpreter() {
             "re".to_string(),
             value::Value::Native(native::Re::build()),
         );
+        my_vm.builtins.insert(
+            "process".to_string(),
+            value::Value::Native(native::Process::build()),
+        );
         unsafe {
             GLOBAL_INTERPRETER = Some(Interpreter {
                 vm: my_vm,

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -1,5 +1,5 @@
 use crate::vm::{StackEntry, VMFnPrototype};
-use crate::{compiler, lexer, native, parser, state, stmt, value, vm};
+use crate::{compiler, embed, lexer, native, parser, state, stmt, value, vm};
 use std::collections::{HashMap, HashSet};
 use std::panic;
 use std::rc::Rc;
@@ -87,7 +87,7 @@ fn setup_global_interpreter() {
         );
         my_vm.builtins.insert(
             "process".to_string(),
-            value::Value::Native(native::Process::build()),
+            value::Value::Native(native::Process::build(embed::is_embedded())),
         );
         unsafe {
             GLOBAL_INTERPRETER = Some(Interpreter {

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,21 +12,106 @@ mod token;
 mod value;
 mod vm;
 
-use std::fs::{canonicalize, read, write};
+use std::{fs::{canonicalize, read, write}, process::exit, ptr};
+use const_random::const_random;
 
 use std::{env, panic};
 
+#[repr(C)]
+struct Marker {
+    magic_pattern: [u8; 512],
+    is_embedded: u8,
+}
+
+const fn new_marker() -> Marker {
+    Marker{
+        magic_pattern: const_random!([u8; 512]),
+        is_embedded: 0,
+    }
+}
+
+static EMBEDDED_MARKER: Marker = new_marker();
+
+fn is_embedded() -> bool {
+    let embedded_indicator = &EMBEDDED_MARKER.is_embedded as *const u8;
+    unsafe {
+        // Need to perform this trick to read the actual memory location.
+        // Otherwise during compilation Rust does static analysis and assumes
+        // this function always returns the same value.
+        return ptr::read_volatile(embedded_indicator) != 0;
+    }
+}
+
+fn magic_pattern() -> &'static[u8; 512] {
+    &EMBEDDED_MARKER.magic_pattern
+}
+
+fn find_position(haystack: &Vec<u8>, needle: &[u8; 512]) -> Option<usize> {
+    if haystack.len() < needle.len() {
+        return None;
+    }
+    for i in 0..=haystack.len() - needle.len() {
+        if &haystack[i..i + needle.len()] == needle.as_ref() {
+            return Some(i);
+        }
+    }
+    None
+}
+
+fn embed_file(compiled_script: String, output_binary: String) {
+    let exe_path = env::current_exe().unwrap();
+    let mut exe_contents = read(exe_path).unwrap();
+    let pattern = magic_pattern();
+    if let Some(pos) = find_position(&exe_contents, pattern) {
+        exe_contents[pos+512] = 1;
+        let mut compiled_content = read(compiled_script).unwrap();
+        for i in 0..512 {
+            exe_contents.push(pattern[i]);
+        }
+        exe_contents.append(&mut compiled_content);
+        write(output_binary, exe_contents).unwrap();
+    }
+}
+
+fn execute_embedded() {
+    let exe_path = env::current_exe().unwrap();
+    interpreter::set_absolute_path(exe_path.clone().to_str().unwrap().to_string());
+
+    let exe_contents = read(exe_path).unwrap();
+    let pattern = magic_pattern();
+    let offset: usize = 512;
+    let first_match = find_position(&exe_contents, pattern).unwrap();
+    let remaining = &exe_contents[first_match+offset..].to_vec();
+    let pos = find_position(remaining, pattern).unwrap();
+    let compiled_content = &remaining[pos+offset..];
+    
+    if !interpreter::run_interpreter_from_bytecode(&compiled_content) {
+        println!("Could not read embedded script");
+        exit(1);
+    }
+}
+
+const GENERAL_USAGE: &'static str = r##"Usage:
+    grotsky [script.gr | bytecode.grc]
+    grotsky compile script.gr
+    grotsky embed bytecode.grc
+"##;
+
 fn main() {
-    let args: Vec<String> = env::args().collect();
-    if args.len() < 2 {
-        println!("Usage:\n\tgrotsky [filename]\n\tgrotsky compile [filename]\n");
+    if is_embedded() {
+        execute_embedded();
         return;
     }
+    let args: Vec<String> = env::args().collect();
+    if args.len() < 2 {
+        println!("{}", GENERAL_USAGE);
+        exit(1);
+    }
     let content: Vec<u8>;
-    let mut abs_path = if args[1] == "compile" {
+    let mut abs_path = if args[1] == "compile" || args[1] == "embed" {
         if args.len() != 3 {
-            println!("Usage:\n\tgrotsky [filename]\n\tgrotsky compile [filename]\n");
-            return;
+            println!("{}", GENERAL_USAGE);
+            exit(1);
         }
         canonicalize(&args[2]).unwrap()
     } else {
@@ -34,6 +119,17 @@ fn main() {
     };
     let abs_path_str = abs_path.to_string_lossy();
     let abs_path_string = String::from(abs_path_str);
+    if args[1] == "embed" {
+        if abs_path.extension().unwrap_or_default() != "grc" {
+            println!("Can only embed a .grc file");
+            exit(1);
+        }
+        let mut new_abs_path = abs_path.clone();
+        new_abs_path.set_extension("exe");
+        embed_file(abs_path_string, String::from(new_abs_path.to_string_lossy()));
+        return;
+    }
+
     interpreter::set_absolute_path(abs_path_string);
     content = read(interpreter::get_absolute_path()).unwrap();
     let grotsky_debug = env::var("GROTSKY_DEBUG").unwrap_or("0".to_string());

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,5 @@
 mod compiler;
+mod embed;
 mod errors;
 mod expr;
 mod instruction;
@@ -12,84 +13,9 @@ mod token;
 mod value;
 mod vm;
 
-use std::{fs::{canonicalize, read, write}, process::exit, ptr};
-use const_random::const_random;
+use std::{fs::{canonicalize, read, write}, process::exit};
 
 use std::{env, panic};
-
-#[repr(C)]
-struct Marker {
-    magic_pattern: [u8; 512],
-    is_embedded: u8,
-}
-
-const fn new_marker() -> Marker {
-    Marker{
-        magic_pattern: const_random!([u8; 512]),
-        is_embedded: 0,
-    }
-}
-
-static EMBEDDED_MARKER: Marker = new_marker();
-
-fn is_embedded() -> bool {
-    let embedded_indicator = &EMBEDDED_MARKER.is_embedded as *const u8;
-    unsafe {
-        // Need to perform this trick to read the actual memory location.
-        // Otherwise during compilation Rust does static analysis and assumes
-        // this function always returns the same value.
-        return ptr::read_volatile(embedded_indicator) != 0;
-    }
-}
-
-fn magic_pattern() -> &'static[u8; 512] {
-    &EMBEDDED_MARKER.magic_pattern
-}
-
-fn find_position(haystack: &Vec<u8>, needle: &[u8; 512]) -> Option<usize> {
-    if haystack.len() < needle.len() {
-        return None;
-    }
-    for i in 0..=haystack.len() - needle.len() {
-        if &haystack[i..i + needle.len()] == needle.as_ref() {
-            return Some(i);
-        }
-    }
-    None
-}
-
-fn embed_file(compiled_script: String, output_binary: String) {
-    let exe_path = env::current_exe().unwrap();
-    let mut exe_contents = read(exe_path).unwrap();
-    let pattern = magic_pattern();
-    if let Some(pos) = find_position(&exe_contents, pattern) {
-        exe_contents[pos+512] = 1;
-        let mut compiled_content = read(compiled_script).unwrap();
-        for i in 0..512 {
-            exe_contents.push(pattern[i]);
-        }
-        exe_contents.append(&mut compiled_content);
-        write(output_binary, exe_contents).unwrap();
-    }
-}
-
-fn execute_embedded() {
-    let exe_path = env::current_exe().unwrap();
-    interpreter::set_absolute_path(exe_path.clone().to_str().unwrap().to_string());
-
-    let exe_contents = read(exe_path).unwrap();
-    let pattern = magic_pattern();
-    let offset: usize = 512;
-    let first_match = find_position(&exe_contents, pattern).unwrap();
-    let remaining = &exe_contents[first_match+offset..].to_vec();
-    let pos = find_position(remaining, pattern).unwrap();
-    let compiled_content = &remaining[pos+offset..];
-    
-    if !interpreter::run_interpreter_from_bytecode(&compiled_content) {
-        println!("Could not read embedded script");
-        exit(1);
-    }
-}
 
 const GENERAL_USAGE: &'static str = r##"Usage:
     grotsky [script.gr | bytecode.grc]
@@ -98,8 +24,8 @@ const GENERAL_USAGE: &'static str = r##"Usage:
 "##;
 
 fn main() {
-    if is_embedded() {
-        execute_embedded();
+    if embed::is_embedded() {
+        embed::execute_embedded();
         return;
     }
     let args: Vec<String> = env::args().collect();
@@ -126,7 +52,7 @@ fn main() {
         }
         let mut new_abs_path = abs_path.clone();
         new_abs_path.set_extension("exe");
-        embed_file(abs_path_string, String::from(new_abs_path.to_string_lossy()));
+        embed::embed_file(abs_path_string, String::from(new_abs_path.to_string_lossy()));
         return;
     }
 

--- a/src/native.rs
+++ b/src/native.rs
@@ -1034,7 +1034,7 @@ impl Re {
 pub struct Process {}
 
 impl Process {
-    pub fn build() -> NativeValue {
+    pub fn build(is_embedded: bool) -> NativeValue {
         let mut process = NativeValue{
             props: HashMap::new(),
             callable: None,
@@ -1042,7 +1042,7 @@ impl Process {
             baggage: None,
         };
         let mut argv: Vec<String> = env::args().collect();
-        if argv.len() >= 2 {
+        if !is_embedded && argv.len() >= 2 {
             argv.drain(0..1);
         }
         let argv_values = Value::List(MutValue::new(ListValue{

--- a/src/native.rs
+++ b/src/native.rs
@@ -1,6 +1,6 @@
 use socket2::{Domain, Socket};
 use std::cmp::Ordering;
-use std::io::{Read, Write};
+use std::io::{stdin, BufRead, Read, Write};
 use std::net::{Shutdown, ToSocketAddrs};
 use std::ops::DerefMut;
 use std::{
@@ -34,6 +34,27 @@ impl IO {
             .unwrap();
         println!("{}", text);
         return Ok(Value::Nil);
+    }
+
+    fn readln(values: Vec<Value>) -> Result<Value, RuntimeErr> {
+        if !values.is_empty() {
+            return Err(ERR_INVALID_NUMBER_ARGUMENTS);
+        }
+        let stdin = stdin();
+        let line = stdin.lock()
+            .lines()
+            .next();
+        if line.is_none() {
+            return Ok(Value::Nil);
+        }
+        let line_unwrapped = line.unwrap();
+        if line_unwrapped.is_err() {
+            return Err(RuntimeErr{
+                msg: "Could not read from stdin",
+                signal: None,
+            });
+        }
+        return Ok(Value::String(StringValue { s: line_unwrapped.unwrap() }));
     }
 
     fn clock(values: Vec<Value>) -> Result<Value, RuntimeErr> {
@@ -211,6 +232,12 @@ impl IO {
             bind: false,
             baggage: None,
         };
+        let readln = NativeValue {
+            props: HashMap::new(),
+            callable: Some(&IO::readln),
+            bind: false,
+            baggage: None,
+        };
         let clock = NativeValue {
             props: HashMap::new(),
             callable: Some(&IO::clock),
@@ -249,6 +276,8 @@ impl IO {
         };
         io.props
             .insert("println".to_string(), Value::Native(println));
+        io.props
+            .insert("readln".to_string(), Value::Native(readln));
         io.props.insert("clock".to_string(), Value::Native(clock));
         io.props
             .insert("readFile".to_string(), Value::Native(read_file));
@@ -959,6 +988,26 @@ impl Re {
         return Ok(Value::List(MutValue::new(ListValue{elements: result})));
     }
 
+    pub fn regex_match(values: Vec<Value>) -> Result<Value, RuntimeErr> {
+        if values.len() != 2 {
+            return Err(ERR_INVALID_NUMBER_ARGUMENTS);
+        }
+        let regex_value = match values.first().unwrap() {
+            Value::String(s) => s,
+            _ => {
+                return Err(ERR_EXPECTED_STRING);
+            }
+        };
+        let string_value = match values.last().unwrap() {
+            Value::String(s) => s,
+            _ => {
+                return Err(ERR_EXPECTED_STRING);
+            }
+        };
+        let re = Regex::new(regex_value.s.as_str()).unwrap();
+        Ok(Value::Bool(BoolValue { b: re.is_match(string_value.s.as_str()) }))
+    }
+
     pub fn build() -> NativeValue {
         let mut re = NativeValue {
             props: HashMap::new(),
@@ -972,6 +1021,34 @@ impl Re {
             bind: false,
             baggage: None,
         }));
+        re.props.insert("match".to_string(), Value::Native(NativeValue{
+            props: HashMap::new(),
+            callable: Some(&Self::regex_match),
+            bind: false,
+            baggage: None,
+        }));
         return re;
+    }
+}
+
+pub struct Process {}
+
+impl Process {
+    pub fn build() -> NativeValue {
+        let mut process = NativeValue{
+            props: HashMap::new(),
+            callable: None,
+            bind: false,
+            baggage: None,
+        };
+        let mut argv: Vec<String> = env::args().collect();
+        if argv.len() >= 2 {
+            argv.drain(0..1);
+        }
+        let argv_values = Value::List(MutValue::new(ListValue{
+            elements: argv.iter().map(|a| Value::String(StringValue{s:a.clone()})).collect(),
+        }));
+        process.props.insert("argv".to_string(), argv_values);
+        return process;
     }
 }

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -336,11 +336,28 @@ impl VM {
                 }
                 OpCode::Return => {
                     let stack = self.stack.pop().unwrap();
+                    let mut return_value = None;
 
-                    // Store return values
-                    if inst.b == inst.a + 2 && stack.result_register > 0 {
-                        self.activation_records[stack.sp + (stack.result_register - 1) as usize] =
-                            self.activation_records[sp + inst.a as usize].clone();
+                    // Read return value
+                    if inst.b == inst.a + 2 {
+                        return_value = Some(self.activation_records[sp + inst.a as usize].clone());
+                    }
+
+                    if self.stack.len() == 0 {
+                        // Exit program
+                        let mut exit_code = 0;
+                        if let Some(v) = &return_value {
+                            if let Value::Number(n) = v.as_val() {
+                                if n.n >= 0.0 && n.n < 256.0 && n.n.fract() == 0.0 {
+                                    exit_code = n.n as i32;
+                                }
+                            }
+                        }
+                        std::process::exit(exit_code);
+                    }
+
+                    if return_value.is_some() && stack.result_register > 0 {
+                        self.activation_records[stack.sp + (stack.result_register - 1) as usize] = return_value.unwrap();
                     }
 
                     // Drop current stack frame


### PR DESCRIPTION
The ability to create executables with an embedded Grotsky script was added.

Can be used with:

```
$ grotsky embed script.grc
```

Also updated readme with more examples and reference of the stdlib.

Added native values to read line from stdin and to read argv.